### PR TITLE
install gpgme gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,9 @@ The name of the hiera-gpg package. Default: hiera-gpg or platform specific
 The ensure value of the hiera-gpg package. Default: present
 #### `hiera_gpg_install_options`
 The install\_options of the hiera-gpg package. Default: undef
+#### `ruby_gpg_package_name`
+The name of the ruby_gpg package. Default: gpgme or platform specific
+#### `ruby_gpg_ensure`
+The ensure value of the ruby_gpg package. Default: present
+#### `ruby_gpg_install_options`
+The install\_options of the ruby_gpg package. Default: undef

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The above will put the following contents in `hiera.yaml`:
   will automatically install the `hiera-eyaml-gpg` and `gpgme` packages. If you
   are using [puppetserver](https://github.com/puppetlabs/puppet-server) with the
   [puppetserver_gem](https://github.com/puppetlabs/puppetlabs-puppetserver_gem)
-  provider, you will need to use the `ruby_gpg` package which does not any C
-  extensions. See https://tickets.puppetlabs.com/browse/SERVER-497 for more
+  provider, you will need to use the `ruby_gpg` package which does not have any
+  C extensions. See https://tickets.puppetlabs.com/browse/SERVER-497 for more
   info.
 * In case you specify `deep` or `deeper` merge\_behavior, then this module will
   automatically install the `deep_merge` package.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ The above will put the following contents in `hiera.yaml`:
   automatically install the `hiera-gpg` or the `hiera-eyaml` package
   accordingly.
 * In case you specify `gpg_gnupghome` under the eyaml data, then this module
-  will automatically install the `hiera-eyaml-gpg` package.
+  will automatically install the `hiera-eyaml-gpg` and `gpgme` packages. If you
+  are using [puppetserver](https://github.com/puppetlabs/puppet-server) with the
+  [puppetserver_gem](https://github.com/puppetlabs/puppetlabs-puppetserver_gem)
+  provider, you will need to use the `ruby_gpg` package which does not any C
+  extensions. See https://tickets.puppetlabs.com/browse/SERVER-497 for more
+  info.
 * In case you specify `deep` or `deeper` merge\_behavior, then this module will
   automatically install the `deep_merge` package.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,6 +104,18 @@
 # The install_options of the hiera-gpg package
 # Default: undef
 #
+# [*ruby_gpg_package_name*]
+# The name of the ruby_gpg package
+# Default: gpgme or platform specific
+#
+# [*ruby_gpg_ensure*]
+# The ensure value of the ruby_gpg package
+# Default: present
+#
+# [*ruby_gpg_install_options*]
+# The install_options of the ruby_gpg package
+# Default: undef
+#
 # == Example:
 #
 #    class { 'hiera':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,10 @@ class hiera (
   $hiera_gpg_package_name     = $hiera::params::hiera_gpg_package_name,
   $hiera_gpg_ensure           = 'present',
   $hiera_gpg_install_options  = undef,
+  $ruby_gpg_package_name      = $hiera::params::ruby_gpg_package_name,
+  $ruby_gpg_ensure            = 'present',
+  $ruby_gpg_install_options   = undef,
+
 ) inherits hiera::params {
 
   if $backends { validate_hash($backends) }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -33,10 +33,10 @@ class hiera::package {
         provider        => $hiera::provider,
         install_options => $hiera::eyaml_gpg_install_options,
       }
-      package { $ruby_gpg_package_name:
-        ensure          => $ruby_gpg_package_name,
-        provider        => $ruby_gpg_ensure,
-        install_options => $ruby_gpg_install_options,
+      package { $hiera::ruby_gpg_package_name:
+        ensure          => $hiera::ruby_gpg_ensure,
+        provider        => $hiera::provider,
+        install_options => $hiera::ruby_gpg_install_options,
       }
     }
   }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -33,6 +33,11 @@ class hiera::package {
         provider        => $hiera::provider,
         install_options => $hiera::eyaml_gpg_install_options,
       }
+      package { $ruby_gpg_package_name:
+        ensure          => $ruby_gpg_package_name,
+        provider        => $ruby_gpg_ensure,
+        install_options => $ruby_gpg_install_options,
+      }
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class hiera::params {
       $hiera_gpg_package_name  = 'hiera-gpg'
       $eyaml_package_name      = 'hiera-eyaml'
       $eyaml_gpg_package_name  = 'hiera-eyaml-gpg'
+      $ruby_gpg_package_name   = 'gpgme'
     }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,6 +13,7 @@ describe 'hiera' do
     it { should_not contain_package('hiera-gpg') }
     it { should_not contain_package('hiera-eyaml') }
     it { should_not contain_package('hiera-eyaml-gpg') }
+    it { should_not contain_package('gpgme') }
     it { should contain_file('/etc/puppet/hiera.yaml').with_content("---\n:backends:\n  - yaml\n:yaml:\n  :datadir: /etc/puppet/hieradata\n") }
     it { should contain_file('/etc/hiera.yaml').with(
       :ensure => 'link',
@@ -99,6 +100,7 @@ describe 'hiera' do
         let(:params) { {:backends => {'eyaml' => {'data' => 'fake'} } } }
         it { should contain_package('hiera-eyaml') }
         it { should_not contain_package('hiera-eyaml-gpg') }
+        it { should_not contain_package('gpgme') }
       end
 
       context "with eyaml-gpg" do
@@ -108,6 +110,7 @@ describe 'hiera' do
         } } } }
         it { should contain_package('hiera-eyaml') }
         it { should contain_package('hiera-eyaml-gpg') }
+        it { should contain_package('gpgme') }
       end
     end
   end


### PR DESCRIPTION
Either the gpgme or ruby_gpg gems are needed for hiera-eyaml-gpg to work per the documentation for hiera-eyaml-gpg . I chose gpgme as the default since the author recommends it but added documentation how puppetserver (jruby) won't work with it.
